### PR TITLE
Fix lost stdout/stderr in secondary threads

### DIFF
--- a/spylon_kernel/scala_interpreter.py
+++ b/spylon_kernel/scala_interpreter.py
@@ -361,9 +361,9 @@ class ScalaInterpreter(object):
         """
         fd = open(filename, 'r')
         while True:
-            line = fd.readline()
-            if line:
-                fn(line)
+            chars = fd.read(4096)
+            if chars:
+                fn(chars)
                 await asyncio.sleep(0, loop=self.loop)
             else:
                 await asyncio.sleep(0.01, loop=self.loop)

--- a/test/test_scala_kernel.py
+++ b/test/test_scala_kernel.py
@@ -104,7 +104,6 @@ def test_init_magic_completion(spylon_kernel):
     assert set(result['matches']) == {'launcher.conf.spark.executor.cores'}
 
 
-@pytest.mark.skip(reason="temp until codecov is restored, failing because of #26")
 def test_stdout(spylon_kernel):
     spylon_kernel.do_execute_direct('''
         Console.err.println("Error")


### PR DESCRIPTION
**NOTE**: Builds on #30 which should be merged first. 

Inject code to set Console stdout/stderr before executing user code. Origin code set them once in the main thread only. Spark creates additional threads and these were still being directed to the terminal.

It'd be nice if we could wrap the creation of the SparkContext in a block that does the redirect so that Spark's threads inherit our settings. However, because we're using pyspark to do that initialization, we don't have good control over that step.

This PR also increases the file read buffer size from Scala to Python from a line per poll to 4096 bytes. This reduces a visible lag in results appearing in a Jupyter notebook, and stabilizes the read size instead of having some very short and some very long reads.

Fixes #26 and #22. 