### PR TITLE
Fix #26 - Rework stdout/stderr handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,4 +38,4 @@ release: clean ## Make a pypi release of a tagged build
 	$(SA) $(ENV) && python setup.py sdist register upload
 
 test: ## Make a test run
-	$(SA) $(ENV) && python run_tests.py -vxrs --capture=sys --color=yes
+	$(SA) $(ENV) && python run_tests.py -vxrs --color=yes

--- a/spylon_kernel/init_spark_magic.py
+++ b/spylon_kernel/init_spark_magic.py
@@ -19,15 +19,15 @@ class InitSparkMagic(Magic):
 
     Attributes
     ----------
-    env : __builtins__
-        Copy of the Python builtins
+    env : dict
+        Copy of the Python builtins plus a spylon.spark.launcher.SparkConfiguration
+        object for use when initializing the Spark context
     log : logging.Logger
         Logger for this instance
     """
     def __init__(self, kernel):
         super(InitSparkMagic, self).__init__(kernel)
         self.env = globals()['__builtins__'].copy()
-        self.env['application_name'] = None
         self.env['launcher'] = spylon.spark.launcher.SparkConfiguration()
         self.log = logging.Logger(self.__class__.__name__)
 
@@ -42,9 +42,9 @@ class InitSparkMagic(Magic):
         Example
         -------
         %%init_spark
-        application_name = "My Fancy App"
         launcher.jars = ["file://some/jar.jar"]
         launcher.master = "local[4]"
+        launcher.conf.spark.app.name = "My Fancy App"
         launcher.conf.spark.executor.cores = 8
         """
         # Evaluate the cell contents as Python

--- a/spylon_kernel/init_spark_magic.py
+++ b/spylon_kernel/init_spark_magic.py
@@ -31,15 +31,15 @@ class InitSparkMagic(Magic):
         self.env['launcher'] = spylon.spark.launcher.SparkConfiguration()
         self.log = logging.Logger(self.__class__.__name__)
 
-    # Use argparse to parse the whitespace delimited cell magic options
+    # Use optparse to parse the whitespace delimited cell magic options
     # just as we would parse a command line.
     @option(
         "--stderr", action="store_true", default=False,
         help="Capture stderr in the notebook instead of in the kernel log"
     )
     def cell_init_spark(self, stderr=False):
-        """%%init_spark --stderr CODE - starts a SparkContext with a custom
-        configuration defined using Python code
+        """%%init_spark [--stderr] - starts a SparkContext with a custom
+        configuration defined using Python code in the body of the cell
 
         Includes a `spylon.spark.launcher.SparkConfiguration` instance
         in the variable `launcher`. Looks for an `application_name`

--- a/spylon_kernel/init_spark_magic.py
+++ b/spylon_kernel/init_spark_magic.py
@@ -49,10 +49,8 @@ class InitSparkMagic(Magic):
         """
         # Evaluate the cell contents as Python
         exec(self.code, self.env)
-        # Use the launcher and application_name as arguments to spylon to
-        # initialize a spark session
-        init_spark(conf=self.env['launcher'],
-                   application_name=self.env['application_name'])
+        # Use the launcher to initialize a spark session
+        init_spark(conf=self.env['launcher'])
         # Do not evaluate the cell contents using the kernel
         self.evaluate = False
 

--- a/spylon_kernel/init_spark_magic.py
+++ b/spylon_kernel/init_spark_magic.py
@@ -2,7 +2,7 @@
 import logging
 import spylon.spark
 
-from metakernel import Magic
+from metakernel import Magic, option
 from .scala_interpreter import init_spark
 
 try:
@@ -31,9 +31,15 @@ class InitSparkMagic(Magic):
         self.env['launcher'] = spylon.spark.launcher.SparkConfiguration()
         self.log = logging.Logger(self.__class__.__name__)
 
-    def cell_init_spark(self):
-        """Starts a SparkContext with a custom configuration defined
-        using Python code.
+    # Use argparse to parse the whitespace delimited cell magic options
+    # just as we would parse a command line.
+    @option(
+        "--stderr", action="store_true", default=False,
+        help="Capture stderr in the notebook instead of in the kernel log"
+    )
+    def cell_init_spark(self, stderr=False):
+        """%%init_spark --stderr CODE - starts a SparkContext with a custom
+        configuration defined using Python code
 
         Includes a `spylon.spark.launcher.SparkConfiguration` instance
         in the variable `launcher`. Looks for an `application_name`
@@ -50,7 +56,7 @@ class InitSparkMagic(Magic):
         # Evaluate the cell contents as Python
         exec(self.code, self.env)
         # Use the launcher to initialize a spark session
-        init_spark(conf=self.env['launcher'])
+        init_spark(conf=self.env['launcher'], capture_stderr=stderr)
         # Do not evaluate the cell contents using the kernel
         self.evaluate = False
 

--- a/spylon_kernel/scala_interpreter.py
+++ b/spylon_kernel/scala_interpreter.py
@@ -363,9 +363,12 @@ class ScalaInterpreter(object):
             Callback function that handles chunks of text
         """
         while True:
+            # Specify a max read size so the read doesn't block indefinitely
+            # Using a value less than the typical default max pipe size
+            # and greater than a single system page.
             buff = fd.read(8192)
             if buff:
-                ioloop.IOLoop.instance().add_callback(fn, buff.decode('utf-8'))
+                fn(buff.decode('utf-8'))
 
     def interpret(self, code):
         """Interprets a block of Scala code.

--- a/spylon_kernel/scala_interpreter.py
+++ b/spylon_kernel/scala_interpreter.py
@@ -327,27 +327,27 @@ class ScalaInterpreter(object):
         """
         self._stderr_handlers.append(handler)
 
-    def handle_stdout(self, line):
+    def handle_stdout(self, chunk):
         """Passes a chunk of Scala stdout to registered handlers.
 
         Parameters
         ----------
-        line : str
+        chunk : str
             Chunk of text
         """
         for handler in self._stdout_handlers:
-            handler(line)
+            handler(chunk)
 
-    def handle_stderr(self, line):
+    def handle_stderr(self, chunk):
         """Passes a chunk of Scala stderr to registered handlers.
 
         Parameters
         ----------
-        line : str
+        chunk : str
             Chunk of text
         """
         for handler in self._stderr_handlers:
-            handler(line)
+            handler(chunk)
 
     def _read_stream(self, fd, fn):
         """Reads bytes from a file descriptor, utf-8 decodes them, and passes them

--- a/spylon_kernel/scala_interpreter.py
+++ b/spylon_kernel/scala_interpreter.py
@@ -1,22 +1,23 @@
 """Scala interpreter supporting async I/O with the managing Python process."""
-import asyncio
 import atexit
 import logging
 import os
 import pathlib
 import shutil
 import signal
+import subprocess
 import tempfile
+import threading
 
-from asyncio import Future
 from collections import namedtuple
 from concurrent.futures import ThreadPoolExecutor
 from typing import Callable, Union, List, Any
 
 import spylon.spark
+from tornado import ioloop
 
 # Global singletons
-SparkState = namedtuple('SparkState', 'spark_session spark_jvm_helpers')
+SparkState = namedtuple('SparkState', 'spark_session spark_jvm_helpers spark_jvm_proc')
 spark_state = None
 scala_intp = None
 
@@ -65,6 +66,30 @@ def init_spark(conf=None):
 
     # Get the application name from the spylon configuration object
     application_name = conf.conf._conf_dict.get('spark.app.name', DEFAULT_APPLICATION_NAME)
+
+    # Force spylon to "discover" the spark python path so that we can import pyspark
+    conf._init_spark()
+
+    # Patch the pyspark.java_gateway.Popen instance to force it to pipe to the parent
+    # process so that we can catch all output from the Scala interpreter and Spark
+    # objects we're about to create
+    # Note: Making this an official part of the pyspark.java_gateway.launch_gateway
+    #
+    import pyspark.java_gateway
+    spark_jvm_proc = None
+    def Popen(*args, **kwargs):
+        """Wraps subprocess.Popen to force stdout and stderr from the child process
+        to pipe to this process without buffering.
+        """
+        nonlocal spark_jvm_proc
+        # Override these in kwargs to avoid duplicate value errors
+        kwargs['bufsize'] = 0
+        kwargs['stdout'] = subprocess.PIPE
+        kwargs['stderr'] = subprocess.PIPE
+        spark_jvm_proc = subprocess.Popen(*args, **kwargs)
+        return spark_jvm_proc
+    pyspark.java_gateway.Popen = Popen
+
     # Create a new spark context using the configuration
     spark_context = conf.spark_context(application_name)
 
@@ -75,7 +100,7 @@ def init_spark(conf=None):
     # Create the singleton SparkState
     spark_session = SparkSession(spark_context)
     spark_jvm_helpers = SparkJVMHelpers(spark_session._sc)
-    spark_state = SparkState(spark_session, spark_jvm_helpers)
+    spark_state = SparkState(spark_session, spark_jvm_helpers, spark_jvm_proc)
     return spark_state
 
 def get_web_ui_url(sc):
@@ -130,7 +155,7 @@ def initialize_scala_interpreter():
     ScalaInterpreter
     """
     # Initialize Spark first if it isn't already
-    spark_session, spark_jvm_helpers = init_spark()
+    spark_session, spark_jvm_helpers, spark_jvm_proc = init_spark()
 
     # Get handy JVM references
     jvm = spark_session._jvm
@@ -157,7 +182,7 @@ def initialize_scala_interpreter():
     interp_arguments = spark_jvm_helpers.to_scala_list(
         ["-Yrepl-class-based", "-Yrepl-outdir", output_dir,
          "-classpath", jars, "-deprecation:false"
-         ]
+        ]
     )
     settings = jvm.scala.tools.nsc.Settings()
     settings.processArguments(interp_arguments, True)
@@ -177,16 +202,9 @@ def initialize_scala_interpreter():
 
     # Ensure that sc and spark are bound in the interpreter context.
     intp.interpret("""
-        @transient val spark = if (org.apache.spark.repl.Main.sparkSession != null) {
-            org.apache.spark.repl.Main.sparkSession
-        } else {
-            org.apache.spark.repl.Main.createSparkSession()
-        }
-        @transient val sc = {
-            val _sc = spark.sparkContext
-            _sc
-        }
-        """)
+        @transient val spark = org.apache.spark.repl.Main.sparkSession
+        @transient val sc = spark.sparkContext
+    """)
     # Import Spark packages for convenience
     intp.interpret('\n'.join([
         "import org.apache.spark.SparkContext._",
@@ -241,24 +259,16 @@ class ScalaInterpreter(object):
         This is used to return output data from the REPL.
     log : logging.Logger
         Logger for this instance
-    loop : asyncio.AbstractEventLoop, optional
-        Asyncio eventloop
     web_ui_url : str
         URL of the Spark web UI associated with this interpreter
     """
     executor = ThreadPoolExecutor(1)
 
-    def __init__(self, jvm, jimain, jbyteout, loop: Union[None, asyncio.AbstractEventLoop]=None):
+    def __init__(self, jvm, jimain, jbyteout):
         self.jvm = jvm
         self.jimain = jimain
         self.jbyteout = jbyteout
         self.log = logging.getLogger(self.__class__.__name__)
-
-        if loop is None:
-            # TODO: We may want to use new_event_loop here to avoid stopping
-            # and starting the main one.
-            loop = asyncio.get_event_loop()
-        self.loop = loop
 
         # Store the state here so that clients of the instance
         # can access them (for now ...)
@@ -269,15 +279,30 @@ class ScalaInterpreter(object):
         self.web_ui_url = get_web_ui_url(self.sc)
         self._jcompleter = None
 
-        # Create a temp directory that will contain the stdout/stderr
-        # files written by Scala and read by Python
-        tempdir = tempfile.mkdtemp()
-        atexit.register(shutil.rmtree, tempdir, True)
-
         # Handlers for dealing with stdout and stderr.
         self._stdout_handlers = []
         self._stderr_handlers = []
-        self._initialize_stdout_err(tempdir)
+
+        # Threads that perform blocking reads on the stdout/stderr
+        # streams from the py4j JVM process.
+        self.stdout_reader = threading.Thread(target=self._read_stream,
+            daemon=True,
+            kwargs=dict(
+                fd=spark_state.spark_jvm_proc.stdout,
+                fn=self.handle_stdout
+            )
+        )
+        self.stderr_reader = threading.Thread(target=self._read_stream,
+            daemon=True,
+            kwargs=dict(
+                fd=spark_state.spark_jvm_proc.stderr,
+                fn=self.handle_stderr
+            )
+        )
+
+        # Start the stream reader threads running
+        self.stdout_reader.start()
+        self.stderr_reader.start()
 
     def register_stdout_handler(self, handler):
         """Registers a handler for the Scala stdout stream.
@@ -299,131 +324,45 @@ class ScalaInterpreter(object):
         """
         self._stderr_handlers.append(handler)
 
-    def _initialize_stdout_err(self, tempdir):
-        """Redirects stdout/stderr in the Scala interpreter to two files in the
-        given tempdir and begins async tasks to poll those files for lines of text.
-
-        Parameters
-        ----------
-        tempdir : str
-            Temporary directory
-        """
-        stdout_file = os.path.abspath(os.path.join(tempdir, 'stdout'))
-        stderr_file = os.path.abspath(os.path.join(tempdir, 'stderr'))
-
-        code = 'Console.set{pipe}(new PrintStream(new FileOutputStream(new File(new java.net.URI("{filename}")), true)))'
-        code = '\n'.join([
-            'import java.io.{PrintStream, FileOutputStream, File}',
-            'import scala.Console',
-            # Set console out and error for the main thread
-            code.format(pipe="Out", filename=pathlib.Path(stdout_file).as_uri()),
-            code.format(pipe="Err", filename=pathlib.Path(stderr_file).as_uri()),
-        ])
-        self.interpret(code)
-
-        self.loop.create_task(self._poll_file(stdout_file, self.handle_stdout))
-        self.loop.create_task(self._poll_file(stderr_file, self.handle_stderr))
-
     def handle_stdout(self, line):
-        """Passes a line of Scala stdout to registered handlers.
+        """Passes a chunk of Scala stdout to registered handlers.
 
         Parameters
         ----------
         line : str
-            Line of text
+            Chunk of text
         """
         for handler in self._stdout_handlers:
             handler(line)
 
     def handle_stderr(self, line):
-        """Passes a line of Scala stderr to registered handlers.
+        """Passes a chunk of Scala stderr to registered handlers.
 
         Parameters
         ----------
         line : str
-            Line of text
+            Chunk of text
         """
         for handler in self._stderr_handlers:
             handler(line)
 
-    async def _poll_file(self, filename, fn):
-        """Busy-polls a file for lines of text and passes them to
-        the provided callback function when available.
+    def _read_stream(self, fd, fn):
+        """Reads bytes from a file descriptor, utf-8 decodes them, and passes them
+        to the provided callback function on the next IOLoop tick.
+
+        Assumes fd.read will block and should be used in a thread.
 
         Parameters
         ----------
-        filename : str
-            Filename to poll for lines of text
+        fd : file
+            File descriptor to read
         fn : callable(str) -> None
-            Callback function that handles lines of text
+            Callback function that handles chunks of text
         """
-        fd = open(filename, 'r')
         while True:
-            chars = fd.read(4096)
-            if chars:
-                fn(chars)
-                await asyncio.sleep(0, loop=self.loop)
-            else:
-                await asyncio.sleep(0.01, loop=self.loop)
-
-    def _interpret_sync(self, code, synthetic=False):
-        """Synchronously interprets a Block of scala code and returns the
-        string output from the Scala REPL.
-
-        If you want to get the result as a Python object, follow this with a
-        call to `last_result`.
-
-        Parameters
-        ----------
-        code : str
-            Scala code to interpret
-        synthetic : bool, optional
-            Use synthetic Scala classes (?)
-
-        Returns
-        -------
-        str
-            String output from the scala REPL
-
-        Raises
-        ------
-        ScalaException
-            When there is a problem interpreting the code
-        """
-        try:
-            res = self.jimain.interpret(code, synthetic)
-            pyres = self.jbyteout.toByteArray().decode("utf-8")
-            # The scala interpreter returns a sentinel case class member here
-            # which is typically matched via pattern matching.  Due to it
-            # having a very long namespace, we just resort to simple string
-            # matching here.
-            result = res.toString()
-            if result == "Success":
-                return pyres
-            elif result == 'Error':
-                raise ScalaException(pyres)
-            elif result == 'Incomplete':
-                raise ScalaException(pyres or '<console>: error: incomplete input')
-            return pyres
-        finally:
-            self.jbyteout.reset()
-
-    async def _interpret_async(self, code, future):
-        """Asynchronously interprets a block of Scala code and sets the
-        output or exception as the result of the future.
-
-        Parameters
-        ----------
-        code : str
-            Scala code to interpret
-        future : Future
-            Future result or exception
-        """
-        try:
-            result = await self.loop.run_in_executor(self.executor, self._interpret_sync, code)
-            future.set_result(result)
-        except Exception as e:
-            future.set_exception(e)
+            buff = fd.read(8192)
+            if buff:
+                ioloop.IOLoop.instance().add_callback(fn, buff.decode('utf-8'))
 
     def interpret(self, code):
         """Interprets a block of Scala code.
@@ -449,10 +388,23 @@ class ScalaInterpreter(object):
         # Ensure the cell is not incomplete. Same approach taken by Apache Zeppelin.
         code = 'print("")\n'+code
 
-        fut = asyncio.Future(loop=self.loop)
-        asyncio.ensure_future(self._interpret_async(code, fut), loop=self.loop)
-        res = self.loop.run_until_complete(fut)
-        return res
+        try:
+            res = self.jimain.interpret(code, False)
+            pyres = self.jbyteout.toByteArray().decode("utf-8")
+            # The scala interpreter returns a sentinel case class member here
+            # which is typically matched via pattern matching.  Due to it
+            # having a very long namespace, we just resort to simple string
+            # matching here.
+            result = res.toString()
+            if result == "Success":
+                return pyres
+            elif result == 'Error':
+                raise ScalaException(pyres)
+            elif result == 'Incomplete':
+                raise ScalaException(pyres or '<console>: error: incomplete input')
+            return pyres
+        finally:
+            self.jbyteout.reset()
 
     def last_result(self):
         """Retrieves the JVM result object from the preceeding call to `interpret`.

--- a/spylon_kernel/scala_magic.py
+++ b/spylon_kernel/scala_magic.py
@@ -70,21 +70,7 @@ class ScalaMagic(Magic):
             self._interp.register_stdout_handler(self.kernel.Write)
             self._interp.register_stderr_handler(self.kernel.Error)
 
-            # Spwan an async loop that yields to the asyncio loop
-            ioloop.IOLoop.current().spawn_callback(self._loop_alive)
-
         return self._interp
-
-    @gen.coroutine
-    def _loop_alive(self):
-        """Coroutine that yields on an interval to allow other event
-        loops to run besides the `tornado.ioloop.IOLoop`.
-        """
-        loop = self._interp.loop
-        while True:
-            loop.call_soon(loop.stop)
-            loop.run_forever()
-            yield gen.sleep(0.01)
 
     def line_scala(self, *args):
         """%scala CODE - evaluates a line of code as Scala

--- a/spylon_kernel/scala_magic.py
+++ b/spylon_kernel/scala_magic.py
@@ -73,7 +73,7 @@ class ScalaMagic(Magic):
         return self._interp
 
     def line_scala(self, *args):
-        """%scala CODE - evaluates a line of code as Scala
+        """%scala - evaluates a line of code as Scala
 
         Parameters
         ----------
@@ -89,7 +89,7 @@ class ScalaMagic(Magic):
         code = " ".join(args)
         self.eval(code, True)
 
-    # Use argparse to parse the whitespace delimited cell magic options
+    # Use optparse to parse the whitespace delimited cell magic options
     # just as we would parse a command line.
     @option(
         "-e", "--eval_output", action="store_true", default=False,

--- a/test/test_scala_kernel.py
+++ b/test/test_scala_kernel.py
@@ -90,7 +90,7 @@ def test_init_magic(spylon_kernel):
 def test_init_magic_with_appname(spylon_kernel):
     code = dedent("""\
         %%init_spark
-        application_name = 'Dave'
+        launcher.conf.spark.app.name = 'Dave'
         launcher.conf.spark.executor.cores = 2
         """)
     spylon_kernel.do_execute(code)

--- a/test/test_scala_kernel.py
+++ b/test/test_scala_kernel.py
@@ -104,6 +104,7 @@ def test_init_magic_completion(spylon_kernel):
     assert set(result['matches']) == {'launcher.conf.spark.executor.cores'}
 
 
+@pytest.mark.skip("needs execute result, stream output synchronization")
 def test_stdout(spylon_kernel):
     spylon_kernel.do_execute_direct('''
         Console.err.println("Error")

--- a/test/test_scala_kernel.py
+++ b/test/test_scala_kernel.py
@@ -1,22 +1,25 @@
-import pytest
-from metakernel.process_metakernel import TextOutput
-
-from spylon_kernel import SpylonKernel
 import re
+import time
+
 from textwrap import dedent
-from jupyter_client.session import Session
 from unittest.mock import Mock
+
+import pytest
+
+from jupyter_client.session import Session
+from metakernel.process_metakernel import TextOutput
+from spylon_kernel import SpylonKernel
 
 
 class MockingSpylonKernel(SpylonKernel):
     """Mock class so that we capture the output of various calls for later inspection.
-
     """
 
     def __init__(self, *args, **kwargs):
         super(MockingSpylonKernel, self).__init__(*args, **kwargs)
         self.Displays = []
         self.Errors = []
+        self.Writes = []
         self.session = Mock(Session)
 
     def Display(self, *args, **kwargs):
@@ -24,6 +27,9 @@ class MockingSpylonKernel(SpylonKernel):
 
     def Error(self, *args, **kwargs):
         self.Errors.append((args, kwargs))
+
+    def Write(self, *args, **kwargs):
+        self.Writes.append((args, kwargs))
 
 
 @pytest.fixture(scope="module")
@@ -96,11 +102,11 @@ def test_init_magic_completion(spylon_kernel):
     assert set(result['matches']) == {'launcher.conf.spark.executor.cores'}
 
 
-@pytest.mark.skip("fails randomly, maybe because interpreter is reused")
-def test_stderr(spylon_kernel):
+@pytest.mark.skip('fails randomly, possibly because of mock reuse across tests')
+def test_stdout(spylon_kernel):
     spylon_kernel.do_execute_direct('''
-        Console.err.println("Error")
+        Console.println("test_stdout")
         // Sleep for a bit since the process for getting text output is asynchronous
         Thread.sleep(1000)''')
-    error, _ = spylon_kernel.Errors.pop()
-    assert error[0].strip() == 'Error'
+    writes, _ = spylon_kernel.Writes.pop()
+    assert writes[0].strip() == 'test_stdout'

--- a/test/test_scala_kernel.py
+++ b/test/test_scala_kernel.py
@@ -90,7 +90,7 @@ def test_init_magic(spylon_kernel):
 def test_init_magic_with_appname(spylon_kernel):
     code = dedent("""\
         %%init_spark
-        launcher.conf.spark.app.name = 'Dave'
+        launcher.conf.spark.app.name = 'test-app-name'
         launcher.conf.spark.executor.cores = 2
         """)
     spylon_kernel.do_execute(code)

--- a/test/test_scala_kernel.py
+++ b/test/test_scala_kernel.py
@@ -70,7 +70,7 @@ def test_last_result(spylon_kernel):
     val foo = LastResult(8)
     """)
     foo = spylon_kernel.get_variable("foo")
-    assert "foo"
+    assert foo
 
 
 def test_help(spylon_kernel):
@@ -80,14 +80,6 @@ def test_help(spylon_kernel):
 
 
 def test_init_magic(spylon_kernel):
-    code = dedent("""\
-        %%init_spark
-        launcher.conf.spark.executor.cores = 2
-        """)
-    spylon_kernel.do_execute(code)
-
-
-def test_init_magic_with_appname(spylon_kernel):
     code = dedent("""\
         %%init_spark
         launcher.conf.spark.app.name = 'test-app-name'

--- a/test/test_scala_kernel.py
+++ b/test/test_scala_kernel.py
@@ -104,12 +104,11 @@ def test_init_magic_completion(spylon_kernel):
     assert set(result['matches']) == {'launcher.conf.spark.executor.cores'}
 
 
-@pytest.mark.skip("needs execute result, stream output synchronization")
-def test_stdout(spylon_kernel):
+@pytest.mark.skip("fails randomly, maybe because interpreter is reused")
+def test_stderr(spylon_kernel):
     spylon_kernel.do_execute_direct('''
         Console.err.println("Error")
         // Sleep for a bit since the process for getting text output is asynchronous
         Thread.sleep(1000)''')
     error, _ = spylon_kernel.Errors.pop()
     assert error[0].strip() == 'Error'
-

--- a/test_spylon_kernel_jkt.py
+++ b/test_spylon_kernel_jkt.py
@@ -40,6 +40,14 @@ class SpylonKernelTests(jupyter_kernel_test.KernelTests):
 
     code_generate_error = "4 / 0"
 
+    code_execute_result = [{
+        'code': 'val x = 1',
+        'result': 'x: Int = 1\n'
+    }, {
+        'code': 'val y = 1 to 3',
+        'result': 'y: scala.collection.immutable.Range.Inclusive = Range(1, 2, 3)\n'
+    }]
+
     spark_configured = False
 
     def setUp(self):

--- a/test_spylon_kernel_jkt.py
+++ b/test_spylon_kernel_jkt.py
@@ -1,8 +1,10 @@
 """Example use of jupyter_kernel_test, with tests for IPython."""
 
-import unittest
-import jupyter_kernel_test
 import os
+import unittest
+
+import jupyter_kernel_test
+
 from textwrap import dedent
 from unittest import SkipTest
 
@@ -40,6 +42,7 @@ class SpylonKernelTests(jupyter_kernel_test.KernelTests):
     code_generate_error = "4 / 0"
 
     def test_execute_stderr(self):
+        raise SkipTest("needs execute result, stream output synchronization")
         if not self.code_stderr:
             raise SkipTest
 
@@ -56,6 +59,7 @@ class SpylonKernelTests(jupyter_kernel_test.KernelTests):
             self.assertTrue(False, "Expected at least one 'stream' message of type 'stderr'")
 
     def test_execute_stdout(self):
+        raise SkipTest("needs execute result, stream output synchronization")
         if not self.code_hello_world:
             raise SkipTest
 

--- a/test_spylon_kernel_jkt.py
+++ b/test_spylon_kernel_jkt.py
@@ -5,9 +5,8 @@ import unittest
 
 import jupyter_kernel_test
 
+from spylon_kernel.scala_interpreter import init_spark
 from textwrap import dedent
-from unittest import SkipTest
-
 
 coverage_rc = os.path.abspath(os.path.join(os.path.dirname(__file__), ".coveragerc"))
 os.environ["COVERAGE_PROCESS_START"] = coverage_rc
@@ -41,8 +40,15 @@ class SpylonKernelTests(jupyter_kernel_test.KernelTests):
 
     code_generate_error = "4 / 0"
 
+    spark_configured = False
 
+    def setUp(self):
+        """Set up to capture stderr for testing purposes."""
+        super(SpylonKernelTests, self).setUp()
         self.flush_channels()
+        if not self.spark_configured:
+            self.execute_helper(code='%%init_spark --stderr')
+            self.spark_configured = True
 
 
 if __name__ == '__main__':

--- a/test_spylon_kernel_jkt.py
+++ b/test_spylon_kernel_jkt.py
@@ -30,7 +30,7 @@ class SpylonKernelTests(jupyter_kernel_test.KernelTests):
         '''
 
     code_stderr = '''
-        Console.err.println("Error")
+        Console.err.println("oh noes!")
         // Sleep for a bit since the process for getting text output is asynchronous
         Thread.sleep(1000)
         '''
@@ -42,7 +42,6 @@ class SpylonKernelTests(jupyter_kernel_test.KernelTests):
     code_generate_error = "4 / 0"
 
     def test_execute_stderr(self):
-        raise SkipTest("needs execute result, stream output synchronization")
         if not self.code_stderr:
             raise SkipTest
 
@@ -54,12 +53,12 @@ class SpylonKernelTests(jupyter_kernel_test.KernelTests):
         self.assertGreaterEqual(len(output_msgs), 1)
         for msg in output_msgs:
             if (msg['msg_type'] == 'stream') and msg['content']['name'] == 'stderr':
+                self.assertIn('oh noes!', msg['content']['text'])
                 break
         else:
             self.assertTrue(False, "Expected at least one 'stream' message of type 'stderr'")
 
     def test_execute_stdout(self):
-        raise SkipTest("needs execute result, stream output synchronization")
         if not self.code_hello_world:
             raise SkipTest
 

--- a/test_spylon_kernel_jkt.py
+++ b/test_spylon_kernel_jkt.py
@@ -1,15 +1,11 @@
 """Example use of jupyter_kernel_test, with tests for IPython."""
 
-import os
 import unittest
 
 import jupyter_kernel_test
 
 from spylon_kernel.scala_interpreter import init_spark
 from textwrap import dedent
-
-coverage_rc = os.path.abspath(os.path.join(os.path.dirname(__file__), ".coveragerc"))
-os.environ["COVERAGE_PROCESS_START"] = coverage_rc
 
 
 class SpylonKernelTests(jupyter_kernel_test.KernelTests):

--- a/test_spylon_kernel_jkt.py
+++ b/test_spylon_kernel_jkt.py
@@ -41,39 +41,8 @@ class SpylonKernelTests(jupyter_kernel_test.KernelTests):
 
     code_generate_error = "4 / 0"
 
-    def test_execute_stderr(self):
-        if not self.code_stderr:
-            raise SkipTest
 
         self.flush_channels()
-        reply, output_msgs = self.execute_helper(code=self.code_stderr)
-
-        self.assertEqual(reply['content']['status'], 'ok')
-
-        self.assertGreaterEqual(len(output_msgs), 1)
-        for msg in output_msgs:
-            if (msg['msg_type'] == 'stream') and msg['content']['name'] == 'stderr':
-                self.assertIn('oh noes!', msg['content']['text'])
-                break
-        else:
-            self.assertTrue(False, "Expected at least one 'stream' message of type 'stderr'")
-
-    def test_execute_stdout(self):
-        if not self.code_hello_world:
-            raise SkipTest
-
-        self.flush_channels()
-        reply, output_msgs = self.execute_helper(code=self.code_hello_world)
-
-        self.assertEqual(reply['content']['status'], 'ok')
-
-        self.assertGreaterEqual(len(output_msgs), 1)
-        for msg in output_msgs:
-            if (msg['msg_type'] == 'stream') and msg['content']['name'] == 'stdout':
-                self.assertIn('hello, world', msg['content']['text'])
-                break
-        else:
-            self.assertTrue(False, "Expected at least one 'stream' message of type 'stdout' ")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Totally new tact: force pyspark to pipe py4j JVM output back to the parent process and read the streams with a small monkey patch. Opened https://issues.apache.org/jira/browse/SPARK-21094 about making this part of pyspark proper.

This change should completely fix all lost output from Scala and Spark by piping the entire JVM process to the kernel process. There's nowhere else for it to go now. 

Surprisingly, output in the notebook now shows up under the proper cell too, even though the kernel unit tests for stdout/stderr fail now. The issue with the tests is that the main ioloop thread needs to yield to let the child process stream consumer threads make all waiting data available before the main thread can return the kernel execution result. Issue #21 remains open to address the problem. As it stands, the user experience is better at the expense of some protocol tests that were passing without reflecting the brokenness of output previously.

I'm opening this PR to make the changes visible for discussion and QA.